### PR TITLE
Resolutions for SBS 3D

### DIFF
--- a/main/text.cpp
+++ b/main/text.cpp
@@ -1952,7 +1952,7 @@ const char *defaultGameTexts [][2] = {
  {"Deine Version von D2X-XL\npasst nicht zu der Version,\ndie fuer dieses Spiel verwendet wird.", "Your version of D2X-XL\ndoes not match the version\nin use for that game."},
  {"\nerlaubte Schiffe:", "\nships allowed:"},
  {"Oculus Rift", "Oculus Rift"},
- {"3D TV (1080p)", "3D TV (1080p)"},
+ {"SBS 3D", "SBS 3D"},
  {"~FOV: %s", "~FOV: %s"},
  {"~Pupillenabstand: %d mm", "I~PD: %d mm"},
  {"Anaglyphenbrille", "Anaglyph Glasses"},

--- a/menus/configmenu.cpp
+++ b/menus/configmenu.cpp
@@ -126,7 +126,6 @@ do {
 
 	if (gameStates.app.bNostalgia)
 		m.AddMenu ("performance options", TXT_DETAIL_LEVELS, KEY_D, HTX_OPTIONS_DETAIL);
-	if (!ogl.IsSideBySideDevice ())
 		m.AddMenu ("screen res options", TXT_SCREEN_RES, KEY_S, HTX_OPTIONS_SCRRES);
 	m.AddText ("", "");
 	if (gameStates.app.bNostalgia) {

--- a/ogl/gr.cpp
+++ b/ogl/gr.cpp
@@ -405,8 +405,6 @@ int32_t SetSideBySideDisplayMode (void)
 {
 if (gameOpts->render.stereo.nGlasses == GLASSES_OCULUS_RIFT)
 	SetCustomDisplayMode (gameData.renderData.rift.HResolution (), gameData.renderData.rift.VResolution (), 0);
-else if (gameOpts->render.stereo.nGlasses == GLASSES_SHUTTER_HDMI)
-	SetCustomDisplayMode (1920, 1080, 0);
 else
 	return true;
 if (!SetDisplayMode (CUSTOM_DISPLAY_MODE, 0))


### PR DESCRIPTION
- enables screenresolution menu for 3D TV option in rendering menu
- disables enforcing of full-hd resolution for 3D TV
- renames 3D TV to SBS 3D